### PR TITLE
Added friends functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,57 @@
 # Fit-Feed-Api
 A REST API backend for FitFeed based on Spring framework.
+
+## Setup instructions
+To build and run the server locally, follow these steps:
+
+### Prereqs:
+- Docker Desktop
+- IntelliJ Idea (preferred IDE) OR Terminal
+
+### Setup:
+1. Install Docker
+2. Run the Docker containers.
+
+You can either do this via IntelliJ run configurations or terminal.
+
+#### IntelliJ
+Simply run the configuration called `Docker Compose` (or `Docker Compose (dev)` if experiencing connectivity issues).
+
+#### Terminal
+In the project root directory, run the following command:
+```shell
+docker compose up -d
+```
+This command will initialize the Keycloak and MySQL containers locally.
+
+Note: if running on a Mac or experiencing connectivity issues to the containers,
+you can use the alternative docker compose configuration using the following command:
+```shell
+docker compose -f compose-dev.yaml up -d
+```
+
+3. Run the Server.
+
+Again, you can do this via IntelliJ run configuration or terminal.
+
+#### IntelliJ
+Simply run the configuration called `StartServer`, which will handle building and running the server.
+
+#### Terminal
+In the project root directory, run the following commands:
+
+##### Windows
+```shell
+.\gradlew.bat build
+java -jar ./build/libs/api-0.0.1-SNAPSHOT.jar
+```
+
+##### OSX/Linux
+```shell
+./gradlew build
+java -jar ./build/libs/api-0.0.1-SNAPSHOT.jar
+```
+
+4. The server is now running!
+
+You can use the Postman collections to test the endpoints locally :)

--- a/postman/FitFeed API [Dev].postman_collection.json
+++ b/postman/FitFeed API [Dev].postman_collection.json
@@ -82,7 +82,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"workoutName\": \"Test Workout\",\n    \"workoutTimestamp\": 1731004635247,\n    \"exercises\": [\n        {\n            \"exerciseName\": \"Test Exercise 1\",\n            \"sets\": 1,\n            \"reps\": 2,\n            \"weight\": 3.0\n        },\n        {\n            \"exerciseName\": \"Test Exercise 2\",\n            \"sets\": 4,\n            \"reps\": 5,\n            \"weight\": 6.0\n        }\n    ]\n}",
+							"raw": "{\n    \"workoutName\": \"cccc\",\n    \"workoutTimestamp\": 1733126809466,\n    \"exercises\": [\n        {\n            \"exerciseName\": \"Test Exercise 1\",\n            \"sets\": 1,\n            \"reps\": 2,\n            \"weight\": 3.0\n        },\n        {\n            \"exerciseName\": \"Test Exercise 2\",\n            \"sets\": 4,\n            \"reps\": 5,\n            \"weight\": 6.0\n        }\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -166,7 +166,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"postText\": \"This is just a test post.\",\n    \"workoutId\": 1,\n    \"imageUri\": \"https://astrotowing.ca/wp-content/uploads/2020/08/Horizontal-Placeholder-Image.jpg\" \n}",
+							"raw": "{\n    \"postText\": \"dddddd\",\n    \"workoutId\": 2,\n    \"imageUri\": \"https://astrotowing.ca/wp-content/uploads/2020/08/Horizontal-Placeholder-Image.jpg\" \n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -197,6 +197,23 @@
 							],
 							"path": [
 								"posts"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get All Posts",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{BASE_URL}}/all-posts",
+							"host": [
+								"{{BASE_URL}}"
+							],
+							"path": [
+								"all-posts"
 							]
 						}
 					},

--- a/postman/FitFeed API [Dev].postman_collection.json
+++ b/postman/FitFeed API [Dev].postman_collection.json
@@ -7,6 +7,72 @@
 	},
 	"item": [
 		{
+			"name": "Friends",
+			"item": [
+				{
+					"name": "Add Friend",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"friendUsername\": \"alexholt\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{BASE_URL}}/friend",
+							"host": [
+								"{{BASE_URL}}"
+							],
+							"path": [
+								"friend"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get All Friends for User",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{BASE_URL}}/friends",
+							"host": [
+								"{{BASE_URL}}"
+							],
+							"path": [
+								"friends"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Remove Friend",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{BASE_URL}}/friend/b707d0d2-923d-4036-8d59-4f9b6acaf8d7",
+							"host": [
+								"{{BASE_URL}}"
+							],
+							"path": [
+								"friend",
+								"b707d0d2-923d-4036-8d59-4f9b6acaf8d7"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
 			"name": "Workouts",
 			"item": [
 				{
@@ -218,6 +284,34 @@
 							],
 							"path": [
 								"login"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Search",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{BASE_URL}}/search?username=alexholt",
+							"host": [
+								"{{BASE_URL}}"
+							],
+							"path": [
+								"search"
+							],
+							"query": [
+								{
+									"key": "username",
+									"value": "alexholt"
+								},
+								{
+									"key": "user-id",
+									"value": "46b45616-8f1f-4a3b-9118-b9dd4f732431",
+									"disabled": true
+								}
 							]
 						}
 					},

--- a/postman/FitFeed API [Public].postman_collection.json
+++ b/postman/FitFeed API [Public].postman_collection.json
@@ -203,6 +203,23 @@
 					"response": []
 				},
 				{
+					"name": "Get All Posts",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{BASE_URL}}/all-posts",
+							"host": [
+								"{{BASE_URL}}"
+							],
+							"path": [
+								"all-posts"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Get Post By Id",
 					"request": {
 						"method": "GET",

--- a/postman/FitFeed API [Public].postman_collection.json
+++ b/postman/FitFeed API [Public].postman_collection.json
@@ -1,11 +1,77 @@
 {
 	"info": {
-		"_postman_id": "9e18c111-50cd-440a-b291-c2f6ddfadf60",
+		"_postman_id": "eda5c7d0-c951-4b1d-8d15-4ab7d0c15af5",
 		"name": "FitFeed API [Public]",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "39607876"
 	},
 	"item": [
+		{
+			"name": "Friends",
+			"item": [
+				{
+					"name": "Add Friend",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"friendUsername\": \"alexholt\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{BASE_URL}}/friend",
+							"host": [
+								"{{BASE_URL}}"
+							],
+							"path": [
+								"friend"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get All Friends for User",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{BASE_URL}}/friends",
+							"host": [
+								"{{BASE_URL}}"
+							],
+							"path": [
+								"friends"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Remove Friend",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{BASE_URL}}/friend/b707d0d2-923d-4036-8d59-4f9b6acaf8d7",
+							"host": [
+								"{{BASE_URL}}"
+							],
+							"path": [
+								"friend",
+								"b707d0d2-923d-4036-8d59-4f9b6acaf8d7"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
 		{
 			"name": "Workouts",
 			"item": [
@@ -218,6 +284,34 @@
 							],
 							"path": [
 								"login"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Search",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{BASE_URL}}/search?username=alexholt",
+							"host": [
+								"{{BASE_URL}}"
+							],
+							"path": [
+								"search"
+							],
+							"query": [
+								{
+									"key": "username",
+									"value": "alexholt"
+								},
+								{
+									"key": "user-id",
+									"value": "46b45616-8f1f-4a3b-9118-b9dd4f732431",
+									"disabled": true
+								}
 							]
 						}
 					},

--- a/src/main/java/com/example/fitfeed/api/controllers/FriendController.java
+++ b/src/main/java/com/example/fitfeed/api/controllers/FriendController.java
@@ -1,0 +1,57 @@
+package com.example.fitfeed.api.controllers;
+
+import com.example.fitfeed.api.models.FriendLink;
+import com.example.fitfeed.api.models.User;
+import com.example.fitfeed.api.models.dto.FriendRequest;
+import com.example.fitfeed.api.service.FriendService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+public class FriendController {
+
+    @Autowired
+    private FriendService friendService;
+
+    @PostMapping("/friend")
+    public @ResponseBody ResponseEntity<FriendLink> addFriend(JwtAuthenticationToken auth, @RequestBody FriendRequest friendRequest) {
+        if (friendRequest.userId == null) { friendRequest.userId = UUID.fromString(auth.getToken().getSubject()); }
+        FriendLink friendLink = friendService.createFriendLink(friendRequest);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(friendLink);
+    }
+
+    @GetMapping("/friends")
+    public @ResponseBody ResponseEntity<List<User>> getFriends(JwtAuthenticationToken auth) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(friendService.getFriendsForUser(
+                        UUID.fromString(auth.getToken().getSubject())
+                ));
+    }
+
+    @Transactional
+    @DeleteMapping("/friend/{friend-user-id}")
+    public @ResponseBody ResponseEntity<String> removeFriend(JwtAuthenticationToken auth, @PathVariable(name = "friend-user-id") UUID friendUserId) {
+        UUID userId = UUID.fromString(auth.getToken().getSubject());
+        List<User> userFriends = friendService.getFriendsForUser(userId);
+
+        if (userFriends.stream().anyMatch(f -> f.getId().equals(friendUserId))) {
+            friendService.deleteFriendLinkByUserIds(userId, friendUserId);
+            return ResponseEntity
+                    .status(HttpStatus.OK)
+                    .body("Deleted");
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+}

--- a/src/main/java/com/example/fitfeed/api/controllers/KeycloakController.java
+++ b/src/main/java/com/example/fitfeed/api/controllers/KeycloakController.java
@@ -6,11 +6,9 @@ import com.example.fitfeed.api.models.dto.KeycloakUserRequest;
 import com.example.fitfeed.api.models.dto.LoginRequest;
 import com.example.fitfeed.api.service.KeycloakService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.Arrays;
 import java.util.UUID;
 
 @RestController
@@ -27,6 +25,11 @@ public class KeycloakController {
     @PostMapping("/register")
     public @ResponseBody String register(@RequestBody KeycloakUserRequest keycloakUserRequest) {
         return keycloakService.register(keycloakUserRequest);
+    }
+
+    @GetMapping("/search")
+    public @ResponseBody User[] userSearch(@RequestParam(name = "username", required = false) String username, @RequestParam(name = "user-id", required = false) UUID userId) {
+        return (userId != null) ? new User[]{keycloakService.userSearch(userId)} : keycloakService.userSearch(username);
     }
 
 }

--- a/src/main/java/com/example/fitfeed/api/data/FriendRepository.java
+++ b/src/main/java/com/example/fitfeed/api/data/FriendRepository.java
@@ -1,0 +1,15 @@
+package com.example.fitfeed.api.data;
+
+import com.example.fitfeed.api.models.FriendLink;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface FriendRepository extends CrudRepository<FriendLink, Long> {
+
+    void deleteByFriendIDAndUserId(UUID userId, UUID friendId);
+
+    List<FriendLink> findByUserId(UUID friendId);
+
+}

--- a/src/main/java/com/example/fitfeed/api/models/FriendLink.java
+++ b/src/main/java/com/example/fitfeed/api/models/FriendLink.java
@@ -1,0 +1,30 @@
+package com.example.fitfeed.api.models;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Getter @Setter @NoArgsConstructor
+public class FriendLink {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "friend_link_id")
+    private long id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "friend_id", nullable = false)
+    private UUID friendID;
+
+    public FriendLink(UUID userId, UUID friendID) {
+        this.userId = userId;
+        this.friendID = friendID;
+    }
+
+}

--- a/src/main/java/com/example/fitfeed/api/models/dto/FriendRequest.java
+++ b/src/main/java/com/example/fitfeed/api/models/dto/FriendRequest.java
@@ -1,0 +1,21 @@
+package com.example.fitfeed.api.models.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.UUID;
+
+public class FriendRequest {
+
+    @JsonProperty(required = false)
+    public String username;
+
+    @JsonProperty(required = false)
+    public UUID userId;
+
+    @JsonProperty(required = false)
+    public String friendUsername;
+
+    @JsonProperty(required = false)
+    public UUID friendUserId;
+
+}

--- a/src/main/java/com/example/fitfeed/api/security/WebSecurityConfig.java
+++ b/src/main/java/com/example/fitfeed/api/security/WebSecurityConfig.java
@@ -72,7 +72,7 @@ public class WebSecurityConfig {
             requests.requestMatchers("/friend", "/friends", "/friend/{friend-user-id}").authenticated();
             requests.requestMatchers("/me").authenticated();
             requests.requestMatchers("/workout", "/workouts", "/workout/{workout-id}").authenticated();
-            requests.requestMatchers("/post", "/posts", "/post/{post-id}").authenticated();
+            requests.requestMatchers("/post", "/posts", "/post/{post-id}", "/all-posts", "/user-posts/{user-id}").authenticated();
             requests.anyRequest().denyAll(); // todo: add other endpoints to filter chain
         });
 

--- a/src/main/java/com/example/fitfeed/api/security/WebSecurityConfig.java
+++ b/src/main/java/com/example/fitfeed/api/security/WebSecurityConfig.java
@@ -68,6 +68,8 @@ public class WebSecurityConfig {
 
         http.authorizeHttpRequests(requests -> {
             requests.requestMatchers("/login", "/register").permitAll();
+            requests.requestMatchers("/search").authenticated();
+            requests.requestMatchers("/friend", "/friends", "/friend/{friend-user-id}").authenticated();
             requests.requestMatchers("/me").authenticated();
             requests.requestMatchers("/workout", "/workouts", "/workout/{workout-id}").authenticated();
             requests.requestMatchers("/post", "/posts", "/post/{post-id}").authenticated();

--- a/src/main/java/com/example/fitfeed/api/service/FriendService.java
+++ b/src/main/java/com/example/fitfeed/api/service/FriendService.java
@@ -1,0 +1,19 @@
+package com.example.fitfeed.api.service;
+
+import com.example.fitfeed.api.models.FriendLink;
+import com.example.fitfeed.api.models.User;
+import com.example.fitfeed.api.models.dto.FriendRequest;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface FriendService {
+
+    public FriendLink createFriendLink(FriendRequest friendRequest);
+
+    public List<User> getFriendsForUser(UUID userId);
+
+    public FriendLink getFriendLink(Long linkId);
+
+    public void deleteFriendLinkByUserIds(UUID userId, UUID friendUserId);
+}

--- a/src/main/java/com/example/fitfeed/api/service/FriendServiceImpl.java
+++ b/src/main/java/com/example/fitfeed/api/service/FriendServiceImpl.java
@@ -1,0 +1,75 @@
+package com.example.fitfeed.api.service;
+
+import com.example.fitfeed.api.data.FriendRepository;
+import com.example.fitfeed.api.models.FriendLink;
+import com.example.fitfeed.api.models.User;
+import com.example.fitfeed.api.models.dto.FriendRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class FriendServiceImpl implements FriendService {
+
+    @Autowired
+    private FriendRepository friendRepository;
+
+    @Autowired
+    private KeycloakService keycloakService;
+
+    @Override
+    public FriendLink createFriendLink(FriendRequest friendRequest) {
+        if (friendRepository.findByUserId(friendRequest.userId).stream().anyMatch(friendLink -> friendLink.getFriendID().equals(friendRequest.friendUserId))) {
+            throw new HttpClientErrorException(HttpStatus.CONFLICT, "Friend already exists");
+        }
+
+        User userById = null;
+        User userByUsername = null;
+        if (friendRequest.friendUserId != null) {
+            userById = keycloakService.userSearch(friendRequest.friendUserId);
+        }
+        if (friendRequest.friendUsername != null) {
+            User[] users = keycloakService.userSearch(friendRequest.friendUsername);
+            if (users.length > 1) {
+                throw new HttpClientErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "More than one user with Username = " + friendRequest.friendUsername);
+            } else if (users.length == 1) {
+                userByUsername = users[0];
+            }
+        }
+        if (userById == null && userByUsername == null) {
+            throw new HttpClientErrorException(HttpStatus.NOT_FOUND, "User not found");
+        }
+
+        UUID idA = friendRequest.userId;
+        UUID idB = (userById != null) ? userById.getId() : userByUsername.getId();
+        friendRepository.save(new FriendLink(idB, idA));
+        return friendRepository.save(new FriendLink(idA, idB));
+    }
+
+    @Override
+    public List<User> getFriendsForUser(UUID userId) {
+        List<FriendLink> friendLinks = friendRepository.findByUserId(userId);
+        List<User> friends = new ArrayList<>();
+        friendLinks.forEach(friendLink -> {
+            friends.add(keycloakService.userSearch(friendLink.getFriendID()));
+        });
+        return friends;
+    }
+
+    @Override
+    public FriendLink getFriendLink(Long linkId) {
+        return friendRepository.findById(linkId).orElse(null);
+    }
+
+    @Override
+    public void deleteFriendLinkByUserIds(UUID userId, UUID friendUserId) {
+        friendRepository.deleteByFriendIDAndUserId(userId, friendUserId);
+        friendRepository.deleteByFriendIDAndUserId(friendUserId, userId);
+    }
+
+}

--- a/src/main/java/com/example/fitfeed/api/service/KeycloakService.java
+++ b/src/main/java/com/example/fitfeed/api/service/KeycloakService.java
@@ -1,10 +1,17 @@
 package com.example.fitfeed.api.service;
 
 import com.example.fitfeed.api.models.Token;
+import com.example.fitfeed.api.models.User;
 import com.example.fitfeed.api.models.dto.KeycloakUserRequest;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+import java.util.UUID;
 
 public interface KeycloakService {
     public Token login(String username, String password);
 
     public String register(KeycloakUserRequest keycloakUserRequest);
+
+    public User[] userSearch(String username);
+    public User userSearch(UUID userId);
 }


### PR DESCRIPTION
Friends endpoints:

- `POST /friend` adds friend relationship (bi directional, so two rows)
- `GET /friends` returns all `User`s that are the current user's friends.
- `DELETE /friend/{friend-user-id}` removes a user as a friend

Post endpoints:

- `GET /all-posts` gets all posts (current users, and all friends) sorted by workout timestamp
    - todo: add timestamp to posts?
- `GET /user-posts/{user-id}` gets all posts for a specific user (in case getting just one friend's posts or one-by-one is required)